### PR TITLE
Restart snipeit when it fails

### DIFF
--- a/docker/snipeit/docker-compose.yml
+++ b/docker/snipeit/docker-compose.yml
@@ -14,6 +14,7 @@ services:
     networks:
       default:
         ipv4_address: 172.18.0.2
+    restart: unless-stopped
   snipeit: #snipe-it config
     image: linuxserver/snipe-it:latest
     container_name: snipe-it
@@ -37,6 +38,7 @@ services:
     networks:
       default:
         ipv4_address: 172.18.0.3
+    restart: unless-stopped
 volumes: #make sure the volumes are created on docker-compose up
  snipe-db:
     external: false


### PR DESCRIPTION
Adds `restart: on-failure` to the snipe-it compose file.